### PR TITLE
Fix error propagation if starting the VM fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -573,6 +573,8 @@ fn start_vmm(toplevel: TopLevel) -> Result<Option<String>, Error> {
         .map_err(Error::ThreadJoin)?
         .map_err(Error::VmmThread)?;
 
+    r?;
+
     Ok(api_socket_path)
 }
 


### PR DESCRIPTION
Commit 3d906985 ("main: reset tty if starting the VM fails") changed start_vmm() to join the vmm thread if an error happens after the vmm thread is started. The implementation put all the error-prone code that is run after the vmm is started in a closure, to be able to always join the vmm thread, regardless of any error happening. However, it missed propagating the error that might happen inside the closure back to the main function, after joining the vmm thread.

For some cmd line options, the above issue inhibits proper error reporting when starting a VM with invalid commands, as many parameters are parsed after the vmm is started, thus if such parsing fails, no error will be reported back to the user.

See: #5435
Fixes: 3d906985 ("main: reset tty if starting the VM fails")